### PR TITLE
Corrected code fault and made work with the Collapsed Topics / Weeks formats for Moodle 2.1.

### DIFF
--- a/dndupload.js
+++ b/dndupload.js
@@ -29,7 +29,7 @@ M.blocks_dndupload = {
         this.maxsize = maxsize;
         this.addimg = addimg;
 
-        var els = document.getElementsByTagName('li');
+        var els = document.getElementsByClassName('section');
         var self = this;
         for (var i=0; i<els.length; i++) {
             if ((els[i].className.search('section') >= 0)
@@ -217,7 +217,7 @@ M.blocks_dndupload = {
         if (!modsel) {
             var modsel = document.createElement('ul');
             modsel.className = 'section img-text';
-            var contentel = sectionel.lastChild;
+            var contentel = section.lastChild;
             var brel = contentel.lastChild;
             contentel.insertBefore(modsel, brel);
         }


### PR DESCRIPTION
Made work with Collapsed Topics and Weeks whilst retaining compatibility with standard topic's format.  And corrected code bug.

Tested with Moodle 2.1, should work with Moodle 2.0.  Moodle 1.9 to be checked and tested that the same fix can be applied in the same manner.
