### PR TITLE
Using config setting for default display of resources

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -112,7 +112,9 @@ $data->files = false;
 $data->coursemodule = add_course_module($data);
 
 unset($data->id);
-$data->display = RESOURCELIB_DISPLAY_AUTO;
+
+// use default display setting for resources
+$data->display = get_config('resource', 'display'); 
 
 if ($type == 'Files') {
     // Create the relevant file


### PR DESCRIPTION
In the site admin configuration settings for "Default values for activity settings", we set the default display type to be "Force download".

However, the block forces all uploaded content to be RESOURCELIB_DISPLAY_AUTO. I modified the code to use the site setting. But it should default to RESOURCELIB_DISPLAY_AUTO if no site setting is specially set.
