### PR TITLE
Sets default license type and author

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -143,7 +143,9 @@ if ($type == 'Files') {
                       'itemid' => 0,
                       'filepath' => '/',
                       'filename' => $filename,
-                      'userid' => $USER->id
+                      'userid' => $USER->id,
+                      'license' => $CFG->sitedefaultlicense,
+                      'author' => fullname($USER)
                       );
     $fs->create_file_from_pathname($fileinfo, $filesrc);
 


### PR DESCRIPTION
Right now any file that is uploaded using the drag and drop tool has the license and author fields set to null. With this patch it will use the default values that the Moodle file picker has set.
